### PR TITLE
include missing header for OpenCLSolver with g++-8.3

### DIFF
--- a/opm/simulators/wells/StandardWell.hpp
+++ b/opm/simulators/wells/StandardWell.hpp
@@ -23,6 +23,9 @@
 #ifndef OPM_STANDARDWELL_HEADER_INCLUDED
 #define OPM_STANDARDWELL_HEADER_INCLUDED
 
+#if HAVE_CUDA || HAVE_OPENCL
+#include <opm/simulators/linalg/bda/WellContributions.hpp>
+#endif
 
 #include <opm/simulators/wells/RateConverter.hpp>
 #include <opm/simulators/wells/WellInterface.hpp>


### PR DESCRIPTION
Without I got compilation errors.