### PR TITLE
MultisegmentWell::umfpack Needs to be mutable to be modified

### DIFF
--- a/opm/simulators/wells/MultisegmentWell.hpp
+++ b/opm/simulators/wells/MultisegmentWell.hpp
@@ -173,7 +173,7 @@ namespace Opm
         int number_segments_;
 
 #if HAVE_CUDA || HAVE_OPENCL
-        std::shared_ptr<Dune::UMFPack<DiagMatWell> > umfpack;
+        mutable std::shared_ptr<Dune::UMFPack<DiagMatWell> > umfpack;
 #endif
         // components of the pressure drop to be included
         WellSegments::CompPressureDrop compPressureDrop() const;


### PR DESCRIPTION
in a const function. Makes the code compile.
