### PR TITLE
Use amgcl::amgcl target, but only extract INTERFACE_INCLUDE_DIRS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,10 @@ endif()
 find_package(amgcl)
 if(amgcl_FOUND)
   set(HAVE_AMGCL 1)
+  # Linking to target angcl::amgcl drags in OpenMP and -fopenmp as a compile
+  # flag. With that nvcc fails as it does not that flag.
+  # Hence we set AMG_CL_INCLUDE_DIRS.
+  get_property(AMGCL_INCLUDE_DIRS TARGET amgcl::amgcl PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
   include_directories(${AMGCL_INCLUDE_DIRS})
   set_source_files_properties(opm/simulators/linalg/bda/amgclSolverBackend.cpp PROPERTIES LANGUAGE CUDA)
 endif()


### PR DESCRIPTION
There is no AMGCL_INCLUDE_DIRS when using find_package. We now query the target amgcl::amgcl for INTERFACE_INCLUDE_DIRS and store the result in AMGCL_INCLUDE_DIRS.

Note that we cannot link amgcl::amgcl target to libopmsimulators as this sets the -fopenmp flag for all the source files and makes compilation with nvcc fail.